### PR TITLE
Update plugin URI

### DIFF
--- a/domain-mapping.php
+++ b/domain-mapping.php
@@ -1,7 +1,7 @@
 <?php
 /*
 Plugin Name: Domain Mapping
-Plugin URI: https://premium.wpmudev.org/project/domain-mapping/
+Plugin URI: https://github.com/wpmudev/domain-mapping/
 Description: The ultimate Multisite domain mapping plugin - sync cookies, sell domains with eNom, and integrate with Pro Sites.
 Version: 4.4.3.4
 Author: WPMU DEV


### PR DESCRIPTION
To display the new URI of the plugin, important as it is the link showed in the plugin list in the WP dashboard. Correct URI also allows to use some automated update tools from GitHub to WP